### PR TITLE
Fix for signature changes to _on_lobby_data_update

### DIFF
--- a/steam_lobby.gd
+++ b/steam_lobby.gd
@@ -136,7 +136,7 @@ func _update_lobby_members():
 func _on_lobby_invite(inviter, lobby, game):
 	pass
 	
-func _on_lobby_data_update(success, lobby_id, member_id, key):
+func _on_lobby_data_update(success, lobby_id, member_id):
 	if success:
 		# check for host change
 		var host = Steam.getLobbyOwner(_steam_lobby_id)
@@ -145,7 +145,7 @@ func _on_lobby_data_update(success, lobby_id, member_id, key):
 			_steam_lobby_host = host
 		emit_signal("lobby_data_updated", member_id)
 		
-#	print("Lobby Updated %s %s %s %s" % [success, lobby_id, member_id, key])
+#	print("Lobby Updated %s %s %s %s" % [success, lobby_id, member_id])
 
 func _owner_changed(was_steam_id, now_steam_id):
 	emit_signal("lobby_owner_changed", was_steam_id, now_steam_id)


### PR DESCRIPTION
Fix for #6

The newest version of GodotSteam changed the calling convention for the `lobby_data_update` signal (see [lines](https://github.com/Gramps/GodotSteam/blob/8aa1649c2246b3e06b7cc5435b4339eb0406e679/godotsteam/godotsteam.cpp#L9875-L9881)), removing the "key" variable. This PR updates GodotSteamHL to use the new function signature.